### PR TITLE
fix sorting in template

### DIFF
--- a/templates/rssh.conf.j2
+++ b/templates/rssh.conf.j2
@@ -12,7 +12,7 @@ chrootpath = "{{ rssh_chrootpath }}"
 logfacility = {{ rssh_logfacility }} 
 umask = {{ rssh_umask }}
 
-{% for u in rssh_users|sort %}
+{% for u in rssh_users|sort(attribute='name') %}
 {%   if u.access_bits is defined and u.name is defined and u.umask is defined %}
 {%     if u.path is defined %}
 user = "{{ u.name }}:{{ u.umask }}:{{ u.access_bits }}:{{ u.path }}"


### PR DESCRIPTION



While applying a role with 2 or more rssh_users:

```
      rssh_users:
        - name: u1
          access_bits: '00001'
          umask: '022'
      rssh_users:
        - name: u2
          access_bits: '00001'
          umask: '022'
```

 i was getting an error:

```
"
snip 

ansibleError: Unexpected templpating type error occurred on 

snip

not supported between instances of 'dict' and 'dict'"
```

ref:
https://stackoverflow.com/a/5490174
